### PR TITLE
Fix docs and add Markdown test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The following videos demonstrate the Ephemeris Extension Attack on iOS and Andro
 1. **iOS Demonstration**  
    [![Watch the iOS demonstration](https://img.youtube.com/vi/TGCezlx4FQI/0.jpg)](https://youtu.be/TGCezlx4FQI)  
 
-2. **iPhone & Air Pods Pro2 Demonstration**  
-   [![Watch the iPhone & Air Pods Pro2 demonstration](https://img.youtube.com/vi/Zb3lNryc4sc/0.jpg)](https://youtu.be/Zb3lNryc4sc)
+2. **iPhone & AirPods Pro 2 Demonstration**  
+   [![Watch the iPhone & AirPods Pro 2 demonstration](https://img.youtube.com/vi/Zb3lNryc4sc/0.jpg)](https://youtu.be/Zb3lNryc4sc)
 
 ---
 
@@ -96,5 +96,6 @@ original and can be used with `gps-sdr-sim`.
 
 ## Additional Notes
 The research was conducted using BladeRF xA4 as the SDR device and `gps-sdr-sim` for generating spoofed GPS signals. Experiments were performed in both indoor and outdoor environments, confirming the effectiveness and broad applicability of the Ephemeris Extension Attack on both iOS and Android systems, including navigation services like Apple CarPlay and Android Auto.
-
+## Running Tests
+Run `pytest` from the repository root to check for unclosed Markdown code blocks.
 ---

--- a/iOS.md
+++ b/iOS.md
@@ -12,14 +12,14 @@ A vulnerability exists in the GPS modules of both iOS (versions 13 to 18) and An
 
 ---
 
-## Experiment Video
+## Experiment Videos
 The following videos demonstrate the Ephemeris Extension Attack on both iOS and Android systems:  
 
 1. **iOS Demonstration**  
    [![iOS Demonstration](https://img.youtube.com/vi/TGCezlx4FQI/0.jpg)](https://youtu.be/TGCezlx4FQI)
 
-2. **iPhone & Air Pods Pro2 Demonstration**  
-   [![iPhone & Air Pods Pro2 Demonstration](https://img.youtube.com/vi/Zb3lNryc4sc/0.jpg)](https://youtu.be/Zb3lNryc4sc)
+2. **iPhone & AirPods Pro 2 Demonstration**  
+   [![iPhone & AirPods Pro 2 Demonstration](https://img.youtube.com/vi/Zb3lNryc4sc/0.jpg)](https://youtu.be/Zb3lNryc4sc)
 
 ---
 
@@ -101,3 +101,5 @@ The research was conducted using BladeRF xA4 as the SDR device and `gps-sdr-sim`
 1. **Clone the repository:**
    ```bash
    git clone https://github.com/YourRepository/Ephemeris-Extension-PoC.git
+   ```
+No additional steps are required.

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,8 @@
+import pathlib
+import re
+
+def test_markdown_code_fences_closed():
+    for md_path in pathlib.Path('.').rglob('*.md'):
+        text = md_path.read_text(encoding='utf-8')
+        fence_count = len(re.findall(r'^```', text, flags=re.MULTILINE))
+        assert fence_count % 2 == 0, f"Unclosed code block in {md_path}"


### PR DESCRIPTION
## Summary
- fix spelling of AirPods Pro 2 in README and iOS docs
- update iOS docs heading and close usage section
- document how to run tests in README
- add pytest for Markdown code fences

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684051dace8c8330b93cebacbea2faf3